### PR TITLE
add named constants for thresholds

### DIFF
--- a/web3_style_gauge_v2.leo
+++ b/web3_style_gauge_v2.leo
@@ -9,6 +9,9 @@ record GaugePublic {
     score: u8,   // 0–100 overall style score
     class: u8,   // 0=conservative, 1=balanced, 2=aggressive
 }
+const SCORE_MAX: u8 = 100u8;
+const SCORE_LOW_MAX: u8 = 33u8;
+const SCORE_MID_MAX: u8 = 66u8;
 
 /// Compute the overall style score from three 0–100 inputs.
 function compute_score(privacy: u8, soundness: u8, performance: u8) -> u8 {


### PR DESCRIPTION
Avoid magic numbers 33 and 66.