### PR TITLE
Add a comment about public visibility of Gauge records

### DIFF
--- a/web3_style_gauge_v2.leo
+++ b/web3_style_gauge_v2.leo
@@ -1,6 +1,7 @@
 program web3_style_gauge_v2.aleo;
 
 /// Public record of one gauge configuration + computed result.
+/// These outputs are visible on-chain and can be indexed off-chain.
 record GaugePublic {
     owner: address,
     privacy: u8,


### PR DESCRIPTION
explanation of why GaugePublic exists.